### PR TITLE
Correctly handle DNS answers without RDATA

### DIFF
--- a/measurement/dns/answer.go
+++ b/measurement/dns/answer.go
@@ -57,6 +57,8 @@ func (a *Answer) UnmarshalJSON(b []byte) error {
                 return fmt.Errorf("Element within RDATA field unsupported type %T", i)
             }
         }
+    case nil:
+        return nil
     default:
         return fmt.Errorf("RDATA field unsupported type %T", a.data.Rdata)
     }


### PR DESCRIPTION
Some DNS measurements (e.g. continuous measurements) do not have a RDATA
field.

Example:
* Measurement ID: 8319598
* Source: ftp://ftp.ripe.net/ripe/atlas/data/dns-v6-udm-2017-06-12.txt.bz2

The specification [1] also says that RDATA is only used for SOA results.

Therefore DNS results without RDATA should be ignored instead of
throwing an error.

[1] https://atlas.ripe.net/docs/data_struct/#v4610_dns