### PR TITLE
Change traceroute edst to string

### DIFF
--- a/measurement/traceroute/reply.go
+++ b/measurement/traceroute/reply.go
@@ -31,7 +31,7 @@ type Reply struct {
         Err        string          `json:"err"`
         From       string          `json:"from"`
         Ittl       int             `json:"ittl"`
-        Edst       int             `json:"edst"`
+        Edst       string          `json:"edst"`
         Late       int             `json:"late"`
         Mtu        int             `json:"mtu"`
         Rtt        float64         `json:"rtt"`
@@ -86,7 +86,7 @@ func (r *Reply) Ittl() int {
 
 // Destination address in the packet that triggered the error ICMP
 // if different from the target of the measurement (optional).
-func (r *Reply) Edst() int {
+func (r *Reply) Edst() string {
     return r.data.Edst
 }
 


### PR DESCRIPTION
The edst field of traceroute results contains a string (namely the IP
address in regular notation), same as the from field.

Example:
* https://atlas.ripe.net/api/v2/measurements/1430077/results?start=1497231166&stop=1497231166&format=json

The API documentation incorrectly specifies this field to be an int.
