### PR TITLE
Example, Stream

### DIFF
--- a/examples/streamer/main.go
+++ b/examples/streamer/main.go
@@ -13,7 +13,7 @@ var Type = flag.String("type", "", "stream specific measurement type")
 func main() {
     flag.Parse()
 
-    if Type == nil {
+    if Type == nil || *Type == "" {
         log.Fatalf("Need -type")
     }
 


### PR DESCRIPTION
- `example/streamer`: Fix parameter checks
- `stream`: Close #22: Protect channel with a mutex to prevent sending on and/or closing of a closed channel, and deadlocks