### PR TITLE
Updating Reply data structure

### DIFF
--- a/measurement/traceroute/reply.go
+++ b/measurement/traceroute/reply.go
@@ -20,120 +20,128 @@
 package traceroute
 
 import (
-    "encoding/json"
-    "fmt"
+	"encoding/json"
+	"fmt"
 )
 
 // Traceroute reply.
 type Reply struct {
-    data struct {
-        X          string          `json:"x"`
-        Err        string          `json:"err"`
-        From       string          `json:"from"`
-        Ittl       int             `json:"ittl"`
-        Edst       string          `json:"edst"`
-        Late       int             `json:"late"`
-        Mtu        int             `json:"mtu"`
-        Rtt        float64         `json:"rtt"`
-        Size       int             `json:"size"`
-        Ttl        int             `json:"ttl"`
-        Flags      string          `json:"flags"`
-        Dstoptsize int             `json:"dstoptsize"`
-        Hbhoptsize int             `json:"hbhoptsize"`
-        Icmpext    json.RawMessage `json:"icmpext"`
-    }
+	data struct {
+		X          string          `json:"x"`
+		Err        ErrWrapper      `json:"err"`
+		From       string          `json:"from"`
+		Ittl       int             `json:"ittl"`
+		Edst       string          `json:"edst"`
+		Late       int             `json:"late"`
+		Mtu        int             `json:"mtu"`
+		Rtt        float64         `json:"rtt"`
+		Size       int             `json:"size"`
+		Ttl        int             `json:"ttl"`
+		Flags      string          `json:"flags"`
+		Dstoptsize int             `json:"dstoptsize"`
+		Hbhoptsize int             `json:"hbhoptsize"`
+		Icmpext    json.RawMessage `json:"icmpext"`
+	}
 
-    icmpext *Icmpext
+	icmpext *Icmpext
+}
+
+type ErrWrapper string
+
+func (w *ErrWrapper) UnmarshalJSON(data []byte) (err error) {
+	str := string(data)
+	*w = ErrWrapper(str)
+	return nil
 }
 
 func (r *Reply) UnmarshalJSON(b []byte) error {
-    if err := json.Unmarshal(b, &r.data); err != nil {
-        return fmt.Errorf("%s for %s", err.Error(), string(b))
-    }
+	if err := json.Unmarshal(b, &r.data); err != nil {
+		return fmt.Errorf("%s for %s", err.Error(), string(b))
+	}
 
-    if r.data.Icmpext != nil {
-        r.icmpext = &Icmpext{}
-        if err := json.Unmarshal(r.data.Icmpext, r.icmpext); err != nil {
-            return fmt.Errorf("Unable to process ICMP extensions: %s", err.Error())
-        }
-    }
+	if r.data.Icmpext != nil {
+		r.icmpext = &Icmpext{}
+		if err := json.Unmarshal(r.data.Icmpext, r.icmpext); err != nil {
+			return fmt.Errorf("Unable to process ICMP extensions: %s", err.Error())
+		}
+	}
 
-    return nil
+	return nil
 }
 
 // On timeout: "*".
 func (r *Reply) X() string {
-    return r.data.X
+	return r.data.X
 }
 
 // Error ICMP: "N" (network unreachable,), "H" (destination unreachable),
 // "A" (administratively prohibited), "P" (protocol unreachable),
 // "p" (port unreachable) "h" (beyond scope, from fw 4650) (optional).
-func (r *Reply) Err() string {
-    return r.data.Err
+func (r *Reply) Err() ErrWrapper {
+	return r.data.Err
 }
 
 // IPv4 or IPv6 source address in reply.
 func (r *Reply) From() string {
-    return r.data.From
+	return r.data.From
 }
 
 // Time-to-live in packet that triggered the error ICMP. Omitted if equal
 // to 1 (optional).
 func (r *Reply) Ittl() int {
-    return r.data.Ittl
+	return r.data.Ittl
 }
 
 // Destination address in the packet that triggered the error ICMP
 // if different from the target of the measurement (optional).
 func (r *Reply) Edst() string {
-    return r.data.Edst
+	return r.data.Edst
 }
 
 // Number of packets a reply is late, in this case rtt is not
 // present (optional).
 func (r *Reply) Late() int {
-    return r.data.Late
+	return r.data.Late
 }
 
 // Path MTU from a packet too big ICMP (optional).
 func (r *Reply) Mtu() int {
-    return r.data.Mtu
+	return r.data.Mtu
 }
 
 // Round-trip-time of reply, not present when the response is late.
 func (r *Reply) Rtt() float64 {
-    return r.data.Rtt
+	return r.data.Rtt
 }
 
 // Size of reply.
 func (r *Reply) Size() int {
-    return r.data.Size
+	return r.data.Size
 }
 
 // Time-to-live in reply.
 func (r *Reply) Ttl() int {
-    return r.data.Ttl
+	return r.data.Ttl
 }
 
 // TCP flags in the reply packet, for TCP traceroute, concatenated, in
 // the order 'F' (FIN), 'S' (SYN), 'R' (RST), 'P' (PSH), 'A' (ACK),
 // 'U' (URG) (optional).
 func (r *Reply) Flags() string {
-    return r.data.Flags
+	return r.data.Flags
 }
 
 // Size of destination options header (IPv6) (optional).
 func (r *Reply) Dstoptsize() int {
-    return r.data.Dstoptsize
+	return r.data.Dstoptsize
 }
 
 // Size of hop-by-hop options header (IPv6) (optional).
 func (r *Reply) Hbhoptsize() int {
-    return r.data.Hbhoptsize
+	return r.data.Hbhoptsize
 }
 
 // Information when icmp header is found in reply (optional).
 func (r *Reply) Icmpext() *Icmpext {
-    return r.icmpext
+	return r.icmpext
 }


### PR DESCRIPTION
Ever since Version 6610 of Traceroute data, the reply result of a hop has err to be either a string or integer.

Case: Reply
"err" -- (optional) error ICMP: "N" (network unreachable,), "H" (destination unreachable), "A" (administratively prohibited), "P" (protocol unreachable), "p" (port unreachable) "h" (beyond scope, from fw 4650) (string) **Unrecognized error codes are represented as integers**

While using this library on the REST API, I encountered a Parsing error on that exact attribute because it was given a number instead of a string. 

To combat this, I created a type ErrWrapper that is of type string. I set the Err attribute to type ErrWrapper. I made a custom UnMarshal Method on this type to convert it to a string. Let me know if there is a more elegant solution.
