### PR TITLE
Traceroute.Reply.Err

### DIFF
--- a/measurement/traceroute/reply.go
+++ b/measurement/traceroute/reply.go
@@ -62,7 +62,10 @@ func (r *Reply) X() string {
 // "A" (administratively prohibited), "P" (protocol unreachable),
 // "p" (port unreachable) "h" (beyond scope, from fw 4650) (optional).
 func (r *Reply) Err() string {
-    return r.data.Err.(string)
+    if err, ok := r.data.Err.(string); ok {
+        return err
+    }
+    return ""
 }
 
 // IPv4 or IPv6 source address in reply.


### PR DESCRIPTION
- `traceroute/reply`: Fix #28: `Err()`: return empty string if `Err` is not a `string`